### PR TITLE
Fix authorization check for API endpoints

### DIFF
--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -255,7 +255,7 @@ void API::httpApiThreadFn()
                         return;
                     }
                     // if the authorization header is present, we check if it is valid
-                    if (CubeAuth::isAuthorized_authHeader(authHeader)) {
+                    if (!CubeAuth::isAuthorized_authHeader(authHeader)) {
                         res.set_content("Authorization header not valid", "text/plain");
                         res.status = httplib::StatusCode::Forbidden_403;
                         return;


### PR DESCRIPTION
## Summary
- fix boolean logic when validating auth header

## Testing
- `cmake -S . -B build` *(fails: Could NOT find GLEW)*

------
https://chatgpt.com/codex/tasks/task_e_683f3f4b3aec832db1fa54bc7af9eb6c