### PR TITLE
Fix removeEvent bounds check

### DIFF
--- a/src/gui/eventHandler/eventHandler.cpp
+++ b/src/gui/eventHandler/eventHandler.cpp
@@ -212,6 +212,10 @@ bool EventManager::removeEvent(EventHandler* event)
  */
 bool EventManager::removeEvent(int index)
 {
+    if (index < 0 || index >= static_cast<int>(this->events.size())) {
+        CubeLog::error("Index out of range when removing event");
+        return false;
+    }
     delete this->events[index];
     this->events.erase(this->events.begin() + index);
     return true;


### PR DESCRIPTION
## Summary
- guard against invalid indexes in `removeEvent(int)`

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release` *(fails: Could NOT find GLEW)*

------
https://chatgpt.com/codex/tasks/task_e_683f4144f0f0832d92b3b7c3712f20d2