### PR TITLE
Fix comment typos

### DIFF
--- a/src/database/cubeDB.cpp
+++ b/src/database/cubeDB.cpp
@@ -433,7 +433,7 @@ HttpEndPointData_t CubeDB::getHttpEndpointData()
 }
 
 /**
- * @brief Get the Inteface Name for the database endpoints
+ * @brief Get the Interface Name for the database endpoints
  *
  * @return std::string
  */

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1953,7 +1953,7 @@ HttpEndPointData_t GUI::getHttpEndpointData()
 }
 
 /**
- * @brief Get the Inteface Name
+ * @brief Get the Interface Name
  *
  * @return std::string the name of the interface
  */


### PR DESCRIPTION
## Summary
- fix spelling of `Interface` in comments

## Testing
- `cmake ..` (fails: Could NOT find GLEW)


------
https://chatgpt.com/codex/tasks/task_e_683f42050084832dba85f8f4d00520d9