### PR TITLE
Fix logger test include and compile path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -660,7 +660,11 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(googletest)
 
 # Add test executable
-file(GLOB_RECURSE TEST_SOURCES "tests/*.cpp" "tests/**/*.cpp")
+file(GLOB_RECURSE TEST_SOURCES
+    "tests/*.cpp" "tests/**/*.cpp"
+    "src/*.cpp" "src/**/*.cpp" "src/**/**/*.cpp")
+# Exclude the application entry point from the test build
+list(FILTER TEST_SOURCES EXCLUDE REGEX "/main\\.cpp$")
 add_executable(CubeCoreTests ${TEST_SOURCES})
 target_link_libraries(CubeCoreTests PRIVATE
     gtest

--- a/tests/logger/logger.test.cpp
+++ b/tests/logger/logger.test.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
-#include "../src/logger/logger.cpp"
+#include "logger/logger.h"
 #include <iostream>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
## Summary
- use logger header instead of including the cpp in logger tests
- glob src sources for CubeCoreTests and exclude main.cpp

## Testing
- `cmake ..`
- `cmake --build . --target CubeCoreTests -j $(nproc)` *(fails: fatal error: glm/glm.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683f42d363ac832db2490b1242d65db4