### PR TITLE
Fix cleanup bug in API_Builder destructor

### DIFF
--- a/src/api/builder.cpp
+++ b/src/api/builder.cpp
@@ -57,9 +57,7 @@ API_Builder::API_Builder(std::shared_ptr<API> api)
 API_Builder::~API_Builder()
 {
     CubeLog::info("API Builder destroyed");
-    for(size_t i = 0; i < this->interface_objs.size(); i++) {
-        this->interface_objs.erase(this->interface_objs.begin());
-    }
+    this->interface_objs.clear();
 }
 
 /**


### PR DESCRIPTION
## Summary
- clear interface registry in `API_Builder` destructor instead of erasing elements one by one

## Testing
- `cmake ..` *(fails: Could NOT find GLEW)*

------
https://chatgpt.com/codex/tasks/task_e_683f5413099c832d957f77bf3d063df5