### PR TITLE
Allow manual or confirm auth flows and persist web token

### DIFF
--- a/src/api/readme.md
+++ b/src/api/readme.md
@@ -21,7 +21,7 @@ Interface endpoints are exposed at `/InterfaceName-endpoint`.
 
 ### CubeAuth
 - **GET /CubeAuth-authHeader** – Authorize a client and return an authentication header; requires `client_id` and `initial_code`. (Public)
-- **GET /CubeAuth-initCode** – Generate an initial authorization code for a client; requires `client_id`. (Public)
+- **GET /CubeAuth-initCode** – Generate an initial authorization code for a client; requires `client_id`. Pass `return_code=true` to also receive the code and use the confirmation flow. (Public)
 
 ### CubeDB
 - **POST /CubeDB-saveBlob** – Save a blob for a client or app; requires `client_id` or `app_id` and either `stringBlob` or `blob` (base64). (Private)


### PR DESCRIPTION
## Summary
- Let clients request `CubeAuth-initCode` with or without `return_code` to toggle between manual entry and on-device confirmation
- Add checkbox in `auth.js` to select confirmation flow and cache auth tokens in cookies
- Document `return_code` option for init code endpoint

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT: no such file or directory, open '/workspace/Core/package.json')*
- `cmake ..` *(fails: Could NOT find GLEW (missing: GLEW_INCLUDE_DIRS GLEW_LIBRARIES))*

------
https://chatgpt.com/codex/tasks/task_e_689568aa7ac8832dbd482803fc91a880