### PR TITLE
build(benchmarks): link with CubeCoreLib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -725,27 +725,7 @@ if(benchmark_FOUND)
     target_link_libraries(CubeCoreBenchmarks PRIVATE
         benchmark::benchmark
         benchmark::benchmark_main
-        sfml-graphics
-    sfml-audio
-    sfml-network
-    rtaudio
-    ${ALSA_LIBRARIES}
-    ${FREETYPE_LIBRARY}
-    ${OPENGL_LIBRARIES}
-    ${GLEW_LIBRARIES}
-    nlohmann_json::nlohmann_json
-    SQLiteCpp
-    sqlite3
-    ${SODIUM_LIBRARIES}
-    # Qt6::Core
-    # Qt6::SerialPort${WIRINGPI_LIB}
-    whisper
-    OpenSSL::SSL
-    OpenSSL::Crypto
-    infoware
-    pqxx
-    pq
-    spdlog::spdlog_header_only
+        CubeCoreLib
     )
 else()
     message(WARNING "Google Benchmark not found, skipping benchmarks.")


### PR DESCRIPTION
## Summary
- Use CubeCoreLib for benchmark executable

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` *(fails: missing libraries/SQLiteCpp directory and SSL files)*

------
https://chatgpt.com/codex/tasks/task_e_68990146a3e4832d8b428278c8b67f63