### PR TITLE
build: make build server sync optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,9 @@ set(BUILD_BT_MANAGER ON)
 # Comment out the following line to disable translation
 set(TRANSLATE_ENABLED ON)
 
+# Optionally sync build information and artifacts with the build server
+option(ENABLE_BUILD_SERVER "Sync build info/artifacts with server" ON)
+
 # This is a hack to make intellisense work well with a bunch of lambdas
 add_definitions(-D_ENABLE_LAMBDAS)
 
@@ -666,28 +669,30 @@ add_custom_command(
 
 
 # Ensure Python is found
-find_package(Python3 REQUIRED)
-# Variables
-set(BUILD_NUMBER_HEADER "${CMAKE_SOURCE_DIR}/libraries/build_number.h")
-set(UPLOAD_ARTIFACT_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/tooling/upload_artifact.py")
+if(ENABLE_BUILD_SERVER)
+    find_package(Python3 REQUIRED)
 
-add_custom_command(
-    TARGET CubeCore POST_BUILD
-    COMMAND ${PYTHON_EXECUTABLE} "${UPLOAD_ARTIFACT_SCRIPT}" "${CMAKE_SOURCE_DIR}" "${BUILD_NUMBER_HEADER}"
-    DEPENDS "${UPLOAD_ARTIFACT_SCRIPT}"
-    COMMENT "Uploading build to server..."
-)
+    # Variables
+    set(BUILD_NUMBER_HEADER "${CMAKE_SOURCE_DIR}/libraries/build_number.h")
+    set(UPLOAD_ARTIFACT_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/tooling/upload_artifact.py")
 
-set(GET_BUILD_NUMBER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/tooling/get_next_build_number.py")
+    add_custom_command(
+        TARGET CubeCore POST_BUILD
+        COMMAND ${PYTHON_EXECUTABLE} "${UPLOAD_ARTIFACT_SCRIPT}" "${CMAKE_SOURCE_DIR}" "${BUILD_NUMBER_HEADER}"
+        DEPENDS "${UPLOAD_ARTIFACT_SCRIPT}"
+        COMMENT "Uploading build to server..."
+    )
 
-# Custom command to generate the build number header
-add_custom_command(
-    TARGET CubeCore PRE_BUILD
-    # OUTPUT "${BUILD_NUMBER_HEADER}"
-    COMMAND ${PYTHON_EXECUTABLE} "${GET_BUILD_NUMBER_SCRIPT}" "${BUILD_NUMBER_HEADER}" "${CMAKE_SOURCE_DIR}"
-    DEPENDS "${GET_BUILD_NUMBER_SCRIPT}"
-    COMMENT "Fetching build number from server..."
-)
+    set(GET_BUILD_NUMBER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/tooling/get_next_build_number.py")
+
+    # Custom command to generate the build number header
+    add_custom_command(
+        TARGET CubeCore PRE_BUILD
+        COMMAND ${PYTHON_EXECUTABLE} "${GET_BUILD_NUMBER_SCRIPT}" "${BUILD_NUMBER_HEADER}" "${CMAKE_SOURCE_DIR}"
+        DEPENDS "${GET_BUILD_NUMBER_SCRIPT}"
+        COMMENT "Fetching build number from server..."
+    )
+endif()
 
 install(TARGETS CubeCore)
 

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,14 @@ cd build
 cmake ..
 make
 ```
+
+To skip syncing build information or artifacts with the remote server, configure with:
+
+```bash
+cmake .. -DENABLE_BUILD_SERVER=OFF
+```
+
+Alternatively set the environment variable `CUBECORE_OFFLINE=1` to keep the option enabled but avoid network calls during the build.
 4. Run the application:
 ```bash
 ./CubeCore
@@ -89,7 +97,7 @@ Tests use Google Test and are built as `CubeCoreTests`.
 
 Quick start (Debug):
 ```bash
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_BUILD_SERVER=OFF
 cmake --build build -j --target CubeCoreTests
 ctest --test-dir build -C Debug -j
 ```

--- a/tooling/get_next_build_number.py
+++ b/tooling/get_next_build_number.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
+import os
 import sys
 from datetime import datetime
 import urllib.request
 
 def main(output_file, env_file):
+    if os.environ.get("CUBECORE_OFFLINE") == "1":
+        print("CUBECORE_OFFLINE set; skipping build number fetch")
+        with open(output_file, 'w') as f:
+            f.write('#define BUILD_NUMBER 0\n')
+        return
+
     print(f"Updating build number and build info on server")
     url = "http://developmenttracking.lan:9180/TheCube-Core/buildnumber/getNext"
     # set timeout to 10 seconds

--- a/tooling/upload_artifact.py
+++ b/tooling/upload_artifact.py
@@ -42,6 +42,10 @@ def create_multipart(filename: str, file_path: str, boundary: str) -> bytes:
 
 
 def upload_artifact(root_dir: str, header_path: str) -> None:
+    if os.environ.get("CUBECORE_OFFLINE") == "1":
+        print("CUBECORE_OFFLINE set; skipping artifact upload")
+        return
+
     build_number = parse_build_number(header_path)
     artifact_path = os.path.join(root_dir, "build", "bin", "CubeCore")
 


### PR DESCRIPTION
## Summary
- add ENABLE_BUILD_SERVER option to toggle server sync
- allow skipping server calls via CUBECORE_OFFLINE
- document how to build without server dependencies

## Testing
- `python3 -m py_compile tooling/get_next_build_number.py tooling/upload_artifact.py`
- `cmake -S . -B build -DENABLE_BUILD_SERVER=OFF` *(fails: Could NOT find GLEW)*

------
https://chatgpt.com/codex/tasks/task_e_68a119bce8f0832dbda293da28320822