### PR TITLE
feat(decisionEngine): add streaming whisper transcription

### DIFF
--- a/src/decisionEngine/cubeWhisper.cpp
+++ b/src/decisionEngine/cubeWhisper.cpp
@@ -34,15 +34,77 @@ SOFTWARE.
 // CubeWhisper implementation: placeholder that will wrap whisper.cpp APIs.
 // For now, logs initialization and returns a canned transcription.
 #include "cubeWhisper.h"
+#include <sstream>
+
+// static members
+whisper_context* CubeWhisper::ctx = nullptr;
+std::mutex CubeWhisper::partialMutex;
+std::string CubeWhisper::partialResult;
 
 CubeWhisper::CubeWhisper()
 {
-    // TODO: initialize whisper.cpp library and load model(s) in a background thread
+    if (!ctx) {
+        ctx = whisper_init_from_file("libraries/whisper_models/large.bin");
+        if (!ctx)
+            CubeLog::error("Failed to load Whisper model");
+    }
     CubeLog::info("CubeWhisper initialized");
 }
 
-std::string CubeWhisper::transcribe(const std::string& audio)
+std::string CubeWhisper::transcribe(std::shared_ptr<ThreadSafeQueue<std::vector<int16_t>>> audioQueue)
 {
-    CubeLog::info("Transcribing audio");
-    return "This is a test transcription";
+    if (!ctx) {
+        CubeLog::error("Whisper context not initialized");
+        return "";
+    }
+
+    whisper_full_params params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+    params.print_progress = false;
+    params.print_realtime = false;
+    params.print_timestamps = false;
+
+    std::vector<float> pcmf32;
+    {
+        std::lock_guard<std::mutex> lk(partialMutex);
+        partialResult.clear();
+    }
+
+    while (true) {
+        auto dataOpt = audioQueue->pop();
+        if (!dataOpt || dataOpt->empty()) {
+            break;
+        }
+
+        pcmf32.reserve(pcmf32.size() + dataOpt->size());
+        for (int16_t s : *dataOpt)
+            pcmf32.push_back(static_cast<float>(s) / 32768.0f);
+
+        if (whisper_full(ctx, params, pcmf32.data(), pcmf32.size()) != 0) {
+            CubeLog::error("whisper_full failed");
+            break;
+        }
+
+        std::stringstream ss;
+        int n = whisper_full_n_segments(ctx);
+        for (int i = 0; i < n; ++i)
+            ss << whisper_full_get_segment_text(ctx, i);
+
+        {
+            std::lock_guard<std::mutex> lk(partialMutex);
+            partialResult = ss.str();
+        }
+    }
+
+    std::string result;
+    {
+        std::lock_guard<std::mutex> lk(partialMutex);
+        result = partialResult;
+    }
+    return result;
+}
+
+std::string CubeWhisper::getPartialTranscription()
+{
+    std::lock_guard<std::mutex> lk(partialMutex);
+    return partialResult;
 }

--- a/src/decisionEngine/cubeWhisper.h
+++ b/src/decisionEngine/cubeWhisper.h
@@ -45,21 +45,28 @@ SOFTWARE.
 #include <functional>
 #include <httplib.h>
 #include <iostream>
+#include <mutex>
 #include <string>
 #include <thread>
+#include <vector>
 #ifndef LOGGER_H
 #include <logger.h>
 #endif
 #include "nlohmann/json.hpp"
+#include "threadsafeQueue.h"
 #include "utils.h"
 #include "whisper.h"
 
 class CubeWhisper {
 public:
     CubeWhisper();
-    static std::string transcribe(const std::string& audio);
+    static std::string transcribe(std::shared_ptr<ThreadSafeQueue<std::vector<int16_t>>> audioQueue);
+    static std::string getPartialTranscription();
 
 private:
+    static std::mutex partialMutex;
+    static std::string partialResult;
+    static struct whisper_context* ctx;
     std::jthread* transcriberThread;
 };
 


### PR DESCRIPTION
## Summary
- integrate ggml whisper.cpp to stream audio from ThreadSafeQueue
- expose partial transcription retrieval while streaming audio

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` *(fails: libraries/SQLiteCpp missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa444cf010832da917166565c9eeee