### PR TITLE
ci: run tests on master push

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,21 +1,19 @@
-name: C/C++ CI
+name: tests
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: configure
-      run: ./configure
-    - name: make
-      run: make
-    - name: make check
-      run: make check
-    - name: make distcheck
-      run: make distcheck
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo ./install-deps.sh
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+      - name: Build
+        run: cmake --build build -j
+      - name: Run tests
+        run: ctest --test-dir build -C Debug -j


### PR DESCRIPTION
## Summary
- run cmake build and test steps on master branch pushes

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` *(fails: Could NOT find GLEW)*
- `ctest --test-dir build -C Debug -j` *(fails: No tests were found!!!)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c3036938832d84f4e236eab6378e