### PR TITLE
ci: fetch submodules in c-cpp workflow

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Install dependencies
         run: sudo ./install-deps.sh
       - name: Create SSL certs


### PR DESCRIPTION
## Summary
- ensure checkout step pulls submodules recursively in CI tests workflow

## Testing
- `ctest --test-dir build -C Debug -j` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d288ecb0832da475f0a5c269d46d