### PR TITLE
ci: copy env example and guard .env copy

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -19,6 +19,8 @@ jobs:
           cd ssl
           ./generateCert.sh
           cd ..
+      - name: Copy env file
+        run: cp .env.example .env
       - name: Configure
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLING_SCRIPTS=OFF -DENABLE_BUILD_SERVER=OFF
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,10 +411,12 @@ endif()
 # copy ./.env file to the output directory
 if(WIN32)
     set(ENV_DEST_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Debug")
-else()  
+else()
     set(ENV_DEST_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 endif()
-file(COPY ${CMAKE_SOURCE_DIR}/.env DESTINATION ${ENV_DEST_DIR})
+if(EXISTS ${CMAKE_SOURCE_DIR}/.env)
+    file(COPY ${CMAKE_SOURCE_DIR}/.env DESTINATION ${ENV_DEST_DIR})
+endif()
 
 # Create the destination directories if they don't exist
 file(MAKE_DIRECTORY ${SHADER_DEST_DIR})


### PR DESCRIPTION
## Summary
- copy `.env.example` to `.env` during CI tests
- only copy `.env` in CMake if the file exists

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` *(fails: add_subdirectory given source "libraries/SQLiteCpp" which is not an existing directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d31ac5c4832dbefc3aea2f0888f6